### PR TITLE
Fix HTML encoding bug

### DIFF
--- a/exercicio.html
+++ b/exercicio.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <title>Sorteio de Letras do Nome</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add UTF-8 charset meta tag to ensure accented characters display properly

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68459139b144832ba6eed975651dcba0